### PR TITLE
Auto configure the number of compare threads

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -19,7 +19,7 @@ class ScannerImpl : public Scanner
   public:
     ScannerImpl(
       MainWindow* aOwner,
-      uint aThreads = 4)
+      uint aThreads = 0)
     : Scanner(aThreads), Owner(aOwner) {};
 };
 //------------------------------------------------------------------------------

--- a/scanner.cpp
+++ b/scanner.cpp
@@ -32,6 +32,8 @@ class MutexLock
 
 Scanner::Scanner(uint aMaxThreadCount) : MaxThreadCount(aMaxThreadCount)
 {
+  if (MaxThreadCount == 0)
+    MaxThreadCount = std::thread::hardware_concurrency();
 }
 //------------------------------------------------------------------------------
 

--- a/scanner.h
+++ b/scanner.h
@@ -60,7 +60,7 @@ class Scanner : public FolderScanner
     virtual std::string IToS(uint aInt);
 
   public:
-    Scanner(uint aMaxThreadCount = 4);
+    Scanner(uint aMaxThreadCount = 0);
     ~Scanner();
 
     std::set<ulong>        GetGroups();


### PR DESCRIPTION
Until now the number of compare threads was hardcoded to 4. This commit relies on std::thread::hardware_concurrency() to get the number of cpu cores and start that number of threads for compare. Starting twice as much threads might be a faster option but this might lead to extreme IO.