### PR TITLE
Improve the ignore list match

### DIFF
--- a/scanner.cpp
+++ b/scanner.cpp
@@ -93,9 +93,10 @@ bool Scanner::OnFolder(const std::string& aFolder)
   SetState("Scanning " + aFolder);
   ProcessingUpdate();
 
+  const std::string Folder = aFolder + "/";
   for(const std::string& Ignore: FoldersToIgnore)
   {
-    if (aFolder.find(Ignore) != std::string::npos)
+    if (Folder.find(Ignore) != std::string::npos)
       return false;
   }
   return true;


### PR DESCRIPTION
Before this commit the matching of folders was based on full match. So if a match "/home/" is provided the matching will not ignore "/home" folder but only its sub folders. The reason behind is that the folder is checked agains "/home" which does not match "/home/". To fix that an extra "/" is added at the end of the folder so the actual check is made against "/home/" instead of "/home".
So, even though the previous implementation was not wrong, it was kind of unexpected and hard to explain/remember. This commit aims to make it easier to understand.