### PR TITLE
Fix base folder filtering

### DIFF
--- a/folderscanner.cpp
+++ b/folderscanner.cpp
@@ -34,6 +34,9 @@ void FolderScanner::OnFolderError(const std::string& aFolder)
 
 void FolderScanner::Scan(const std::string& aFolder)
 {
+  if (!OnFolder(aFolder))
+    return;
+
   DIR* d_fh;
   struct dirent* entry;
 
@@ -60,7 +63,6 @@ void FolderScanner::Scan(const std::string& aFolder)
           if (strcmp(entry->d_name, "..") == 0 ||
               strcmp(entry->d_name, ".") == 0)
             continue;
-          if (OnFolder(Entry))
             Scan(Entry);
           break;
         case DT_REG:


### PR DESCRIPTION
Move the folder filtering as first step of the Scan method to cover the case when the "base" folder contains some files thus they are still processed. With this change it won't happen anymore.